### PR TITLE
docs: replace local path with GitHub URL in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ YAHOOJP_SECRET={Your YConnect Secret}
 
 ## Upstream Gem Dependency
 
-This app is a downstream consumer of the `omniauth-yahoojp` gem (source: `../omniauth-yahoojp`).
+This app is a downstream consumer of the `omniauth-yahoojp` gem ([GitHub](https://github.com/mikanmarusan/omniauth-yahoojp)).
 
 ### Gem API Surface Used
 


### PR DESCRIPTION
## Summary
- Replace environment-dependent local path `(source: ../omniauth-yahoojp)` with GitHub repository URL in the Upstream Gem Dependency section of CLAUDE.md

## Test plan
- [ ] Verify CLAUDE.md renders correctly with the new markdown link