### PR TITLE
chore: update omniauth-yahoojp to 1.0.1 and refresh CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Application Overview
 
-This is a Rails 5 demonstration application for testing OAuth authentication with Yahoo Japan's YConnect service using the `omniauth-yahoojp` gem. The app provides a complete OAuth flow example, from login initiation to displaying user information retrieved from Yahoo Japan.
+This is a Rails 7 demonstration application for testing OAuth authentication with Yahoo Japan's YConnect service using the `omniauth-yahoojp` gem. The app provides a complete OAuth flow example, from login initiation to displaying user information retrieved from Yahoo Japan.
 
 ## Development Commands
 
@@ -17,23 +17,23 @@ docker-compose build
 docker-compose up
 
 # Run Rails commands inside container
-docker-compose exec web rails console
-docker-compose exec web rails test
-docker-compose exec web bundle exec rails test:system
+docker-compose exec rails rails console
+docker-compose exec rails rails test
+docker-compose exec rails bundle exec rails test:system
 ```
 
 ### Database Commands
 ```bash
 # Database operations (inside container)
-docker-compose exec web rails db:create
-docker-compose exec web rails db:migrate
+docker-compose exec rails rails db:create
+docker-compose exec rails rails db:migrate
 ```
 
 ### Testing
 - **Framework**: Rails default (Minitest)
 - **System tests**: Capybara + Selenium WebDriver
-- **Run tests**: `docker-compose exec web rails test`
-- **System tests**: `docker-compose exec web bundle exec rails test:system`
+- **Run tests**: `docker-compose exec rails rails test`
+- **System tests**: `docker-compose exec rails bundle exec rails test:system`
 
 ## Application Architecture
 
@@ -55,8 +55,8 @@ YAHOOJP_SECRET={Your YConnect Secret}
 ```
 
 ### Dependencies
-- **Rails 5.2.4.3** with Ruby 2.7.1
-- **MySQL 5.7.31** database
+- **Rails 7.1+** with Ruby 3.3
+- **MySQL 8.0** database
 - **OmniAuth gems**: `omniauth`, `omniauth-oauth2`, `omniauth-yahoojp`
 - **Containerized** with Docker Compose
 
@@ -67,14 +67,14 @@ This app is a downstream consumer of the `omniauth-yahoojp` gem ([GitHub](https:
 ### Gem API Surface Used
 
 **Provider config** (`config/initializers/omniauth.rb`):
-- `provider :yahoojp` with options: `scope`
+- `provider :yahoojp` with options: `scope`, `userinfo_access`
 
 **Auth hash consumed** (`app/controllers/sessions_controller.rb`, `app/views/sessions/callback.html.erb`):
 - `auth.uid`
 - `auth.info`: sub, name, given_name, family_name, gender, zoneinfo, locale, birthdate, nickname, picture, email, email_verified, plus Japanese name variants (given_name_ja_kana_jp, given_name_ja_hani_jp, family_name_ja_kana_jp, family_name_ja_hani_jp)
 - `auth.info.address`: country, postal_code, region, locality, formatted
-- `auth.credentials`: token, refresh_token, expires_at
-- `auth.extra`
+- `auth.credentials`: token, refresh_token, expires_at, id_token
+- `auth.extra`, `auth.extra.id_token_claims`
 
 ### Cross-Project Update Rules
 
@@ -86,7 +86,7 @@ When `omniauth-yahoojp` changes its API:
 
 ### Git Operations
 
-This sample app has its own Git repository. All Git operations (branch, commit, push, PR) for this app must be performed in this repository (`omniauth-yahoojp-tester-rails5`), NOT in the upstream gem repository (`omniauth-yahoojp`).
+This sample app has its own Git repository. All Git operations (branch, commit, push, PR) for this app must be performed in this repository (`omniauth-yahoojp-tester-containers`), NOT in the upstream gem repository (`omniauth-yahoojp`).
 
 ## Development Notes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,7 +216,7 @@ GEM
     omniauth-oauth2 (1.9.0)
       oauth2 (>= 2.0.2, < 3)
       omniauth (~> 2.0)
-    omniauth-yahoojp (1.0.0)
+    omniauth-yahoojp (1.0.1)
       httpauth
       json-jwt (>= 1.16.6)
       omniauth (>= 1.0)
@@ -448,7 +448,7 @@ CHECKSUMS
   oauth2 (2.0.18) sha256=bacf11e470dfb963f17348666d0a75c7b29ca65bc48fd47be9057cf91a403287
   omniauth (2.1.4) sha256=42a05b0496f0d22e1dd85d42aaf602f064e36bb47a6826a27ab55e5ba608763c
   omniauth-oauth2 (1.9.0) sha256=ed15f6d9d20991807ce114cc5b9c1453bce3645b64e51c68c90cff5ff153fee8
-  omniauth-yahoojp (1.0.0) sha256=3bb3170171de727f1b53be9837f392a912754ace6d45c5ad6b591698ca0e654d
+  omniauth-yahoojp (1.0.1) sha256=2d4e4de9261c7f870656c39e563f85bd43ed5f233e925f8312124347f8e09d7d
   pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85


### PR DESCRIPTION
## Summary
- Bump `omniauth-yahoojp` from 1.0.0 to 1.0.1 in `Gemfile.lock` (id_token RS256 signature verification added internally, no API surface changes)
- Update `CLAUDE.md` to reflect current state: Rails 7.1+/Ruby 3.3, MySQL 8.0, correct Docker service name (`rails`), correct repo name (`tester-containers`), added `userinfo_access` provider option, `id_token` credential, and `id_token_claims` extra field

## Test plan
- [x] `bundle update --conservative omniauth-yahoojp` — only `omniauth-yahoojp` changed in lockfile
- [x] `docker-compose build` — successful
- [x] Verified `omniauth-yahoojp 1.0.1` loads correctly in container
- [x] CLAUDE.md diff reviewed — all 10 corrections applied

Closes #9