### PR TITLE
feat(env): replace .env files with Docker Compose environment passthrough

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.env
+.env-*
+.env.*
+.envrc
+.git
+.gitignore
+.plans
+tmp/mysql
+log
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -24,9 +24,11 @@ config/master.key
 # Only include if you have production secrets in this file, which is no longer a Rails default
 # config/secrets.yml
 
-# dotenv
-# TODO Comment out this rule if environment variables can be committed
+# dotenv / environment files
 .env
+.env-*
+.env.*
+.envrc
 
 ## Environment normalization:
 /.bundle

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,11 +48,13 @@ docker-compose exec rails rails db:migrate
 - **Routes** (`config/routes.rb`): Simple routing for top and callback endpoints
 
 ### Environment Setup
-Requires `.env` file with Yahoo Japan OAuth credentials:
+Requires host shell environment variables (no `.env` file):
+```bash
+export YAHOOJP_KEY={Your YConnect Client ID}
+export YAHOOJP_SECRET={Your YConnect Secret}
+# Optional: export YAHOOJP_USERINFO_ACCESS=false  # to skip UserInfo API
 ```
-YAHOOJP_KEY={Your YConnect Client ID}
-YAHOOJP_SECRET={Your YConnect Secret}
-```
+Credentials are injected into the container via Docker Compose `environment:` passthrough.
 
 ### Dependencies
 - **Rails 7.1+** with Ruby 3.3

--- a/Gemfile
+++ b/Gemfile
@@ -41,5 +41,3 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'omniauth-yahoojp', '~> 1.0'
-
-gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,10 +102,6 @@ GEM
     debug (1.11.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
-    dotenv (3.2.0)
-    dotenv-rails (3.2.0)
-      dotenv (= 3.2.0)
-      railties (>= 6.1)
     drb (2.2.3)
     erb (6.0.2)
     erubi (1.13.1)
@@ -354,7 +350,6 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   capybara (>= 3.26)
   debug
-  dotenv-rails
   jbuilder (~> 2.7)
   mysql2 (~> 0.5)
   omniauth-yahoojp (~> 1.0)
@@ -395,8 +390,6 @@ CHECKSUMS
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
-  dotenv (3.2.0) sha256=e375b83121ea7ca4ce20f214740076129ab8514cd81378161f11c03853fe619d
-  dotenv-rails (3.2.0) sha256=657e25554ba622ffc95d8c4f1670286510f47f2edda9f68293c3f661b303beab
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.2) sha256=9fe6264d44f79422c87490a1558479bd0e7dad4dd0e317656e67ea3077b5242b
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9

--- a/README.md
+++ b/README.md
@@ -11,14 +11,16 @@ A demonstration Rails application for testing OAuth authentication with Yahoo Ja
 
 ## Setup
 
-### 1. Create `.env` file
+### 1. Set environment variables
 
-Create a `.env` file in the project root with your Yahoo Japan YConnect credentials:
+Export your Yahoo Japan YConnect credentials as shell environment variables:
 
+```bash
+export YAHOOJP_KEY={Your YConnect Client ID}
+export YAHOOJP_SECRET={Your YConnect Secret}
 ```
-YAHOOJP_KEY={Your YConnect Client ID}
-YAHOOJP_SECRET={Your YConnect Secret}
-```
+
+> **Tip**: To persist across shell sessions, add these to your `~/.zshrc` (or `~/.bashrc`), or use [direnv](https://direnv.net/) with an `.envrc` file outside the project directory.
 
 ### 2. Build and start containers
 
@@ -26,6 +28,8 @@ YAHOOJP_SECRET={Your YConnect Secret}
 $ docker-compose build
 $ docker-compose up
 ```
+
+The container will fail fast with a clear error if `YAHOOJP_KEY` or `YAHOOJP_SECRET` are not set.
 
 Access the application at `http://localhost:3000/top`.
 
@@ -38,7 +42,10 @@ Access the application at `http://localhost:3000/top`.
 ### OAuth Configuration
 
 - **Scope**: `openid profile email address`
-- **UserInfo Access**: Enabled (`userinfo_access: true`) — retrieves additional user profile information via the UserInfo API
+- **UserInfo Access**: Controlled by `YAHOOJP_USERINFO_ACCESS` environment variable (default: `true`). Set to `false` to skip UserInfo API calls:
+  ```bash
+  export YAHOOJP_USERINFO_ACCESS=false
+  ```
 
 ## Testing
 

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -4,6 +4,6 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   provider :yahoojp, ENV['YAHOOJP_KEY'], ENV['YAHOOJP_SECRET'],
   {
     :scope => 'openid profile email address',
-    :userinfo_access => true  # If false, not to call UserInfo API にすると UserInfo API を呼ばない
+    :userinfo_access => ENV.fetch('YAHOOJP_USERINFO_ACCESS', 'true') != 'false'
   }
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,11 @@
 services:
   rails:
     build: .
-    env_file: .env
+    environment:
+      - YAHOOJP_KEY
+      - YAHOOJP_SECRET
+      - YAHOOJP_USERINFO_ACCESS
+      - RAILS_ENV=development
     container_name: rails
     depends_on:
       mysql:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 set -e
+
+if [ -z "$YAHOOJP_KEY" ] || [ -z "$YAHOOJP_SECRET" ]; then
+  echo "ERROR: YAHOOJP_KEY and YAHOOJP_SECRET must be set."
+  echo "Run: export YAHOOJP_KEY=xxx YAHOOJP_SECRET=yyy"
+  exit 1
+fi
+
 rm -f /myapp/tmp/pids/server.pid
 bundle check || bundle install
 exec "$@"


### PR DESCRIPTION
## Summary

Remove `.env` file dependency to mitigate the risk of AI coding assistants (Claude Code, Cursor, Copilot) passively reading plaintext credentials from the project directory. Credentials are now injected from host shell environment variables via Docker Compose `environment:` passthrough — no `.env` files exist on disk.

This also removes the `dotenv-rails` gem, adds a `YAHOOJP_USERINFO_ACCESS` env var to toggle UserInfo API access (replacing the old `.env-userinfo` / `.env-nouserinfo` file-swapping workflow), and adds fail-fast validation in `entrypoint.sh` for missing credentials.

## Changes

- **docker-compose.yml**: Replace `env_file: .env` with `environment:` passthrough (variable names only, values from host shell)
- **config/initializers/omniauth.rb**: Make `userinfo_access` configurable via `YAHOOJP_USERINFO_ACCESS` env var (default: `true`)
- **Gemfile / Gemfile.lock**: Remove `dotenv-rails` dependency
- **entrypoint.sh**: Add startup validation — exits immediately with clear error if `YAHOOJP_KEY` or `YAHOOJP_SECRET` are unset
- **.gitignore**: Add `.env-*`, `.env.*`, `.envrc` patterns to prevent future credential file commits
- **.dockerignore** (new): Prevent `.env*` files from being copied into Docker images
- **README.md / CLAUDE.md**: Update setup instructions to use `export` instead of `.env` file creation